### PR TITLE
Introduce "BetterTable" component with simple sort and filter functionality.

### DIFF
--- a/client/themes/default/components/better-table.LICENSE
+++ b/client/themes/default/components/better-table.LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/client/themes/default/components/better-table.vue
+++ b/client/themes/default/components/better-table.vue
@@ -1,0 +1,207 @@
+<!--
+BetterTable Vue.js component - sorting and filtering of <table> contents
+
+Written in 2021 by Jeb Rosen <jeb.rosen@isbscience.org>
+
+To the extent possible under law, the author(s) have dedicated all copyright and
+related and neighboring rights to this software to the public domain worldwide.
+This software is distributed without any warranty.
+
+You should have received a copy of the CC0 Public Domain Dedication along with
+this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+-->
+
+<template lang="pug">
+  table.better-table
+    tr
+      th(v-for='(column, colIndex) in data.columns')
+        | {{column}}
+        button(v-on:click='changeSort(column)')
+          | {{ sortBy === column ? (sortDir === 1 ? "⬇" : "⬆") : "↕" }}
+        select(v-if='shouldFilter(colIndex)' v-on:change='changeFilter(colIndex, $event.target.value)')
+          option(value='<Any>')
+            | &lt;Any&gt;
+          option(v-for='value in data.uniqueValues[colIndex]' v-bind:value='value')
+            | {{value}}
+    tr(v-for='row in visibleRows')
+      td(v-for='cell in row')
+        template(v-if='cell.html')
+          //- This usage of v-html is safe because the same html was already
+          //- present elsewhere on the page (and has already been sanitized
+          //- etc. by the rendering pipeline)
+          span(v-html='cell.html')
+        template(v-else)
+          | {{cell.text}}
+</template>
+
+<script>
+
+// At runtime, this component extracts the contents of the indicated <table>,
+// deletes it, and renders the data with the above template instead. This strategy
+// was chosen to avoid adding a backend rendering step.
+function extractData(table) {
+  const columns = [];
+  const rows = [];
+  const uniqueValues = [];
+
+  table.querySelectorAll("tr").forEach((row, rowIndex) => {
+    if (rowIndex === 0) {
+      // header row
+      row.querySelectorAll("th, td").forEach(td => {
+        columns.push(td.innerText);
+        uniqueValues.push([]);
+      });
+    } else {
+      const cells = [];
+      row.querySelectorAll("th, td").forEach((td, colIndex) => {
+        let text = td.innerText;
+        let values;
+        let html = null;
+        // Don't want to mess up e.g. hyperlinks by splitting them;
+        // for a simple heuristic any cell with child HTML elements
+        // is assumed to be HTML.
+        if (td.children.length > 0) {
+          values = [text];
+          html = td.innerHTML;
+        } else {
+          // split by commas,
+          // ignore any empty values appearing in the middle of the cell
+          // (probably due to extraneous commas)
+          values = text.split(/\s*,\s*/).filter(v => v.length > 0);
+        }
+
+        // if no other values were present, treat as a single empty value
+        // (convenient for filtering to 'blank' rows)
+        if (values.length === 0) {
+          values.push('');
+        }
+
+        values.forEach(v => {
+          if (uniqueValues[colIndex].indexOf(v) === -1) {
+            uniqueValues[colIndex].push(v);
+          }
+        });
+        cells.push({ text, values, html });
+      });
+      rows.push(cells);
+    }
+  });
+
+  table.style.display = 'none';
+
+  uniqueValues.forEach(v => v.sort());
+
+  return { columns, uniqueValues, rows };
+}
+
+export default {
+  data () {
+    return {
+      'data': {},
+      'sortBy': null,
+      'sortDir': 1,
+      'filters': [],
+    };
+  },
+  props: ['for'],
+  computed: {
+    visibleRows() {
+      const rows = [];
+
+      if (!this.$data.data.rows) {
+        return rows;
+      }
+
+      for (const row of this.$data.data.rows) {
+        let visible = true;
+        this.$data.filters.forEach(filter => {
+          if (row[filter.colIndex].values.indexOf(filter.value) === -1) {
+            visible = false;
+          }
+        })
+
+        if (visible) {
+          rows.push(row);
+        }
+      }
+
+      if (this.$data.sortBy) {
+        const sortByIdx = this.$data.data.columns.indexOf(this.$data.sortBy);
+        if (sortByIdx !== -1) {
+          rows.sort((a, b) => {
+            const val1 = a[sortByIdx].text.toLowerCase();
+            const val2 = b[sortByIdx].text.toLowerCase();
+
+            const order = (val1 < val2)
+              ? -1
+              : (val1 > val2)
+                ? 1
+                : 0;
+
+            return order * this.$data.sortDir;
+          });
+        }
+      }
+
+      return rows;
+    }
+  },
+  methods: {
+    changeSort (column) {
+      if (this.$data.sortBy === column) {
+        this.$data.sortDir *= -1;
+      } else {
+        this.$data.sortBy = column;
+        this.$data.sortDir = 1;
+      }
+    },
+    shouldFilter (colIndex) {
+      if (this.$data.data.uniqueValues[colIndex].length <= 1) {
+        // too few values for a filter
+        return false;
+      }
+      if (this.$data.data.rows.length > 0 && (this.$data.data.uniqueValues[colIndex].length / this.$data.data.rows.length) > 0.8) {
+        // almost as many filter values as there are total rows;
+        // unlikely to be a useful filter
+        return false;
+      }
+      return true;
+    },
+    changeFilter (colIndex, value) {
+      const existingFilterIdx = this.$data.filters.findIndex(f => f.colIndex === colIndex);
+      if (existingFilterIdx !== -1) {
+        // 'unset' existing filter by deleting it
+        this.$data.filters.splice(existingFilterIdx, 1);
+      }
+
+      if (value !== null && value !== '<Any>') {
+        this.$data.filters.push({ colIndex, value });
+      }
+    }
+  },
+  mounted () {
+    const table = document.querySelector("table." + this.$props.for);
+    if (table) {
+      const data = extractData(table);
+      this.$data.data = data;
+    } else {
+      console.warn("Could not find table for better-table ('" + this.$props.for + ")'");
+    }
+  },
+}
+</script>
+
+<style lang="scss">
+.better-table select {
+  max-width: 10em;
+  -webkit-appearance: auto;
+  -moz-appearance: auto;
+  border-style: initial;
+}
+
+.better-table th {
+  white-space: nowrap;
+}
+</style>
+
+<!-- vim: set filetype=javascript et ts=2 sw=0 sts=-1 :-->

--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -318,6 +318,7 @@
 <script>
 import { StatusIndicator } from 'vue-status-indicator'
 import Tabset from './tabset.vue'
+import BetterTable from './better-table.vue'
 import NavSidebar from './nav-sidebar.vue'
 import Prism from 'prismjs'
 import mermaid from 'mermaid'
@@ -327,6 +328,7 @@ import ClipboardJS from 'clipboard'
 import Vue from 'vue'
 
 Vue.component('Tabset', Tabset)
+Vue.component('better-table', BetterTable)
 
 Prism.plugins.autoloader.languages_path = '/_assets/js/prism/'
 Prism.plugins.NormalizeWhitespace.setDefaults({

--- a/server/modules/rendering/html-security/renderer.js
+++ b/server/modules/rendering/html-security/renderer.js
@@ -8,7 +8,7 @@ module.exports = {
       const DOMPurify = createDOMPurify(window)
 
       const allowedAttrs = ['v-pre', 'v-slot:tabs', 'v-slot:content', 'target']
-      const allowedTags = ['tabset', 'template']
+      const allowedTags = ['tabset', 'template', 'better-table']
 
       if (config.allowDrawIoUnsafe) {
         allowedTags.push('foreignObject')


### PR DESCRIPTION
For simplicity of implementation and integration/use in the wiki, the
feature is implemented entirely at runtime via a single Vue component:

<better-table for="classname"></better-table>

To use it in the markdown editor the classname must also be set on a
table, like so:

```
| Table | Data  |
| ----- | ----- |
| Hello | World |

{.table-1}

<better-table for="table-1"></better-table>
```

The 'better-table' element is added to the 'default' theme and the list
of allowed tags in the html tag sanitizer so that it can be used in
pages.

